### PR TITLE
Bugfix: interrupt line when out of intersection

### DIFF
--- a/VRED-drawLinesDesktopCollab.py
+++ b/VRED-drawLinesDesktopCollab.py
@@ -266,7 +266,7 @@ def drawDesktop():
     count = count +1
     if mousePos[0] !=-1:
         
-        if ctypes.windll.user32.GetKeyState(leftclick) > 1 :              #ctypes.windll.user32.GetKeyState(leftclick) > 1:     # D button is presse
+        if ctypes.windll.user32.GetKeyState(leftclick) > 1 and x!=0 and y!=0 and z!=0:              #ctypes.windll.user32.GetKeyState(leftclick) > 1:     # D button is presse
             leftclickpressed = True
             if count ==1:
 


### PR DESCRIPTION
Before fix:
<img width="466" alt="before" src="https://user-images.githubusercontent.com/4652710/148235933-01da2313-1a90-407d-b488-c6d090c8a732.PNG">

After fix:
<img width="492" alt="after" src="https://user-images.githubusercontent.com/4652710/148236001-a4a52841-b1ea-4a36-981b-c72ed1a3c312.PNG">

